### PR TITLE
Added Counter and Serves count to Kits table

### DIFF
--- a/app/models/kit.rb
+++ b/app/models/kit.rb
@@ -14,7 +14,6 @@ class Kit < ApplicationRecord
   # URI.regexp provides built-in regexp for different URL types (in this case, http and https)
   validates :link_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]) }
 
-  # TODO: add photos for kits (Cloudinary or something else?) with validation etc
   # TODO: ingredients is currently a string - should we save as an stringified array or a text description or...? Might be some value in storing ingredients to enable a polymorphic search (restaurants, kits, ingredients, descriptions, locations, etc.)
   # TODO: how do we implement delivery options? Each kit should only have one (i.e. all mutually exclusive), but each restaurant might have one or more (UK delivery, EU delivery, click and collect, etc.) if the kits have different options. We could do a look-up from kits to a delivery_options table. At some point, we will need to bubble up these options from the kits to the relevant restaurant so we can display one or more options available with that restaurant (e.g. "We do Click and Collect and UK Delivery")
 end

--- a/db/migrate/20200629090752_add_counter_and_portion_size_to_kits.rb
+++ b/db/migrate/20200629090752_add_counter_and_portion_size_to_kits.rb
@@ -1,0 +1,6 @@
+class AddCounterAndPortionSizeToKits < ActiveRecord::Migration[6.0]
+  def change
+    add_column :kits, :counter, :integer, null: false, default: 0
+    add_column :kits, :serves_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_15_102853) do
+ActiveRecord::Schema.define(version: 2020_06_29_090752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,8 @@ ActiveRecord::Schema.define(version: 2020_06_15_102853) do
     t.bigint "restaurant_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "counter", default: 0, null: false
+    t.integer "serves_count"
     t.index ["restaurant_id"], name: "index_kits_on_restaurant_id"
   end
 


### PR DESCRIPTION
- added in counter and serves_count integer columns to kits table
- updated Airtable to split servings from name of kit (also some kit name cleanup)
- seed file tested and works - as attributes auto-update, no changes needed wooo!